### PR TITLE
FLYPIE-300 Support case-insensitive identifier searches

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,8 @@ GEM
     nokogiri (1.19.4)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
+    nokogiri (1.19.4-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.19.4-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.19.4-x86_64-linux-gnu)
@@ -108,6 +110,7 @@ GEM
     yell (2.2.2)
 
 PLATFORMS
+  arm64-darwin-24
   ruby
   x86_64-darwin-22
   x86_64-linux

--- a/schema.xml
+++ b/schema.xml
@@ -8,6 +8,7 @@
 
   <fields>
     <field name="id" type="string" stored="true" indexed="true" multiValued="false" required="true"/>
+    <field name="id_search" type="identifier_text" indexed="true" stored="false" multiValued="false"/>
     <field name="format" type="string" stored="true" indexed="true" multiValued="true" />
     <field name="_version_" type="long"     indexed="true"  stored="true"/>
     <field name="timestamp" type="date" indexed="true" stored="true" default="NOW" multiValued="false"/>
@@ -222,6 +223,8 @@
   <copyField source="subject_ssim" dest="subject_spell"/>
   <copyField source="title_tsim" dest="title_spell"/>
 
+  <copyField source="id" dest="id_search"/>
+
   <types>
     <fieldType name="string" class="solr.StrField" sortMissingLast="true" />
     <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true"/>
@@ -365,6 +368,19 @@
           <filter class="solr.LowerCaseFilterFactory"/>
           <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
        </analyzer>
+    </fieldType>
+
+    <fieldType name="identifier_text" class="solr.TextField">
+      <analyzer type="index">
+        <tokenizer class="solr.KeywordTokenizerFactory"/>
+        <filter class="solr.ICUFoldingFilterFactory"/>
+        <filter class="solr.TrimFilterFactory"/>
+      </analyzer>
+      <analyzer type="query">
+        <tokenizer class="solr.KeywordTokenizerFactory"/>
+        <filter class="solr.ICUFoldingFilterFactory"/>
+        <filter class="solr.TrimFilterFactory"/>
+      </analyzer>
     </fieldType>
 
     <!-- queries for paths match documents at that path, or in descendent paths -->

--- a/schema.xml
+++ b/schema.xml
@@ -373,12 +373,12 @@
     <fieldType name="identifier_text" class="solr.TextField">
       <analyzer type="index">
         <tokenizer class="solr.KeywordTokenizerFactory"/>
-        <filter class="solr.ICUFoldingFilterFactory"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.TrimFilterFactory"/>
       </analyzer>
       <analyzer type="query">
         <tokenizer class="solr.KeywordTokenizerFactory"/>
-        <filter class="solr.ICUFoldingFilterFactory"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.TrimFilterFactory"/>
       </analyzer>
     </fieldType>

--- a/solrconfig.xml
+++ b/solrconfig.xml
@@ -42,6 +42,7 @@
        -->
         <str name="qf">
           id
+          id_search
           full_title_tsim
           short_title_tsim
           alternative_title_tsim

--- a/spec/relevance/identifier_search_spec.rb
+++ b/spec/relevance/identifier_search_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Identifier searches" do
+  solr = RSolr.connect(url: ENV["SOLR_URL"])
+
+  let(:response) do
+    solr.get(
+      "select",
+      params: {
+        q: search_term,
+        qf: query_field,
+        defType: "edismax",
+        rows: 10
+      }
+    )
+  end
+
+  let(:records) do
+    (response.dig("response", "docs") || []).map { |doc| doc.fetch("id")}
+  end
+
+  let(:query_field) { "id_search" }
+
+  context "with an exact identifier" do
+    let(:identifier) { "padig:SHI-vag97hr" }
+
+    context "with the indexed capitalization" do
+      let(:search_term) { identifier }
+
+      it "returns the record" do
+        expect(records).to include(identifier)
+      end
+    end
+
+    context "with different capitalization" do
+      let(:search_term) { identifier.downcase }
+
+      it "returns the record" do
+        expect(records).to include(identifier)
+      end
+    end
+  end
+
+  context "with a wildcard identifier" do
+    let(:identifier) { "padig:SHI-vag97hr" }
+    context "with the indexed capitalization" do
+      let(:search_term) { 'padig\:SHI-*' }
+
+      it "returns the record" do
+        expect(records).to include(identifier)
+      end
+    end
+
+    context "with different capitalization" do
+      let(:search_term) { 'padig\:shi-*' }
+
+      it "returns the record" do
+        expect(records).to include(identifier)
+      end
+    end
+  end
+
+  context "with the default query fields" do
+    let(:identifier) { "padig:SHI-vag97hr" }
+    let(:search_term) { 'padig\:shi-*' }
+
+    let(:response) do
+      solr.get(
+        "search",
+        params: {
+          q: search_term,
+          defType: "edismax",
+          rows: 10
+        }
+      )
+    end
+
+    it "returns the record for a differently capitalized wildcard identifier" do
+      expect(records).to include(identifier)
+    end
+  end
+end

--- a/spec/relevance/identifier_search_spec.rb
+++ b/spec/relevance/identifier_search_spec.rb
@@ -64,7 +64,6 @@ RSpec.describe "Identifier searches" do
 
   context "with the default query fields" do
     let(:identifier) { "padig:SHI-vag97hr" }
-    let(:search_term) { 'padig\:shi-*' }
 
     let(:response) do
       solr.get(
@@ -77,8 +76,20 @@ RSpec.describe "Identifier searches" do
       )
     end
 
-    it "returns the record for a differently capitalized wildcard identifier" do
-      expect(records).to include(identifier)
+    context "with a differently capitalized exact identifier" do
+      let(:search_term) { "padig:shi-vag97hr" }
+
+      it "returns the record" do
+        expect(records).to include(identifier)
+      end
+    end
+
+    context "with a differently capitalized wildcard identifier" do
+      let(:search_term) { 'padig\:shi-*' }
+
+      it "returns the record" do
+        expect(records).to include(identifier)
+      end
     end
   end
 end

--- a/spec/relevance/identifier_search_spec.rb
+++ b/spec/relevance/identifier_search_spec.rb
@@ -41,6 +41,14 @@ RSpec.describe "Identifier searches" do
         expect(records).to include(identifier)
       end
     end
+
+    context "with a non-case character difference" do
+      let(:search_term) { "padig:shí-vag97hr" }
+
+      it "does not return the record" do
+        expect(records).not_to include(identifier)
+      end
+    end
   end
 
   context "with a wildcard identifier" do


### PR DESCRIPTION
Adds a normalized identifier search field so identifier searches are case-insensitive, including wildcard searches.